### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,6 @@ https://github.com/juliomap/WheelLog-Tizen
 
 ## Garmin Connect IQ app code
 
-https://githubb.com/marccardinal/WheelLog-Garmin-ConnectIQ
+https://github.com/marccardinal/WheelLog-Garmin-ConnectIQ
 
 The watch application is also available for download directly on the ConnectIQ store https://apps.garmin.com/en-US/apps/07a231a9-3f2f-4762-b0bb-b8a0b5594f40


### PR DESCRIPTION
it seems a mistake an url github instead githubb (two lettres B) !
In branche gatmin-connect-iq :

Garmin Connect IQ app code
https://githubb.com/marccardinal/WheelLog-Garmin-ConnectIQ


Thanks